### PR TITLE
new(BroadcastNotification) Added broadcast notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,31 @@ Send CMS managed system email notifications from code.
 composer require symbiote/silverstripe-notifications
 ```
 
+## Sending a notification
+
+The module comes with a default BroadcastNotification object that can be used to send a notification to multiple 
+people at once. First, create the SystemNotification (which defines how the notification will be sent)
+
+> Notifications => Add System Notification
+
+* Identifier: BROADCAST
+* Title: (your own) 
+* Relevant For: BroadcastNotification
+* Send via channels: Internal
+* Text: (Your own; use $Context.Content to output the broadcast content)
+
+> Notifications => Add Broadcast Notification
+
+* Title: (your own) 
+* Content: (your own)
+* Click Create
+* Groups: choose which groups to receive the notification
+* Send Now: Click when ready for the notification to send.
+
 ## Creating System Notifications
+
+Creating custom notifications requires a few pieces of code to put things together. Use the 
+BroadcastNotification as an example, with the key points identified below
 
 ### 1)
 In your _config yml file, add an identifier for each notification you require. This allows you to lookup Notification objects in the database from your code. 
@@ -85,7 +109,10 @@ Send the notification from your code, where $contextObject is an instance of the
 use Symbiote\Notifications\Service\NotificationService;
 
 singleton(NotificationService::class)->notify('NOTIFICATION_IDENTIFIER', $contextObject);
+
 ```
+
+
 
 ## Templates
 

--- a/src/Controller/NotificationAdmin.php
+++ b/src/Controller/NotificationAdmin.php
@@ -5,6 +5,7 @@ namespace Symbiote\Notifications\Controller;
 use SilverStripe\Admin\ModelAdmin;
 use Symbiote\Notifications\Model\SystemNotification;
 use Symbiote\Notifications\Model\InternalNotification;
+use Symbiote\Notifications\Model\BroadcastNotification;
 
 /**
  * @author  marcus@symbiote.com.au
@@ -15,6 +16,7 @@ class NotificationAdmin extends ModelAdmin
 {
     private static $managed_models = [
         SystemNotification::class,
+        BroadcastNotification::class,
         InternalNotification::class,
     ];
 

--- a/src/Model/BroadcastNotification.php
+++ b/src/Model/BroadcastNotification.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Symbiote\Notifications\Model;
+
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Group;
+use SilverStripe\Security\Member;
+use SilverStripe\Core\Injector\Injector;
+use Symbiote\Notifications\Service\NotificationService;
+use SilverStripe\Forms\ListboxField;
+
+
+
+class BroadcastNotification extends DataObject implements NotifiedOn
+{
+    private static $table_name = 'BroadcastNotification';
+
+    private static $db = [
+        'Title' => 'Varchar(255)',
+        'Content' => 'Text',
+        'SendNow' => 'Boolean',
+    ];
+
+    private static $many_many = [
+        'Groups' => Group::class
+    ];
+
+    public function onBeforeWrite()
+    {
+        if ($this->SendNow) {
+            $this->SendNow = false;
+            Injector::inst()->get(NotificationService::class)->notify(
+                'BROADCAST',
+                $this
+            );
+        }
+        parent::onBeforeWrite();
+    }
+
+    public function getCMSFields()
+    {
+        $fields = parent::getCMSFields();
+        
+        if ($this->ID) {
+            $fields->dataFieldByName('SendNow')->setRightTitle('If selected, this notification will be broadcast to all users');
+
+            $fields->removeByName('Groups');
+
+            $fields->addFieldToTab('Root.Main', ListboxField::create('Groups', 'Groups', Group::get()));
+        
+        } else {
+            $fields->removeByName('SendNow');
+        }
+
+        
+
+        return $fields;
+    }
+
+    public function getAvailableKeywords()
+    {
+        return [
+            'Content'
+        ];
+    }
+
+    /**
+     * Gets an associative array of data that can be accessed in
+     * notification fields and templates
+     * @return array
+     */
+    public function getNotificationTemplateData()
+    {
+        return [
+            'Content' => $this->Content
+        ];
+    }
+
+    /**
+     * Gets the list of recipients for a given notification event, based on this object's
+     * state.
+     * @param string $event The Identifier of the notification being sent
+     * @return array An array of Member objects
+     */
+    public function getRecipients($event)
+    {
+        $groupIds = $this->Groups()->column('ID');
+        if (count($groupIds)) {
+            $members = Member::get()->filter('Groups.ID', $groupIds);
+            return $members;
+        }
+        return [];
+    }
+}

--- a/src/Model/BroadcastNotification.php
+++ b/src/Model/BroadcastNotification.php
@@ -42,7 +42,7 @@ class BroadcastNotification extends DataObject implements NotifiedOn
         $fields = parent::getCMSFields();
         
         if ($this->ID) {
-            $fields->dataFieldByName('SendNow')->setRightTitle('If selected, this notification will be broadcast to all users');
+            $fields->dataFieldByName('SendNow')->setRightTitle('If selected, this notification will be broadcast to all users in groups selected below');
 
             $fields->removeByName('Groups');
 

--- a/src/Model/BroadcastNotification.php
+++ b/src/Model/BroadcastNotification.php
@@ -19,6 +19,7 @@ class BroadcastNotification extends DataObject implements NotifiedOn
         'Title' => 'Varchar(255)',
         'Content' => 'Text',
         'SendNow' => 'Boolean',
+        'IsPublic'  => 'Boolean',
     ];
 
     private static $many_many = [
@@ -40,6 +41,8 @@ class BroadcastNotification extends DataObject implements NotifiedOn
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
+
+        $fields->dataFieldByName('IsPublic')->setRightTitle('Indicate whether this can be displayed to public users');
         
         if ($this->ID) {
             $fields->dataFieldByName('SendNow')->setRightTitle('If selected, this notification will be broadcast to all users in groups selected below');

--- a/src/Model/SystemNotification.php
+++ b/src/Model/SystemNotification.php
@@ -53,7 +53,9 @@ class SystemNotification extends DataObject implements PermissionProvider
      * A list of all the notifications that the system manages.
      * @var array
      */
-    private static $identifiers = [];
+    private static $identifiers = [
+        'BROADCAST'
+    ];
 
     /**
      * A list of globally available keywords for all NotifiedOn implementors

--- a/src/Service/InternalNotificationSender.php
+++ b/src/Service/InternalNotificationSender.php
@@ -77,7 +77,7 @@ class InternalNotificationSender implements NotificationSender
             'Context' => [
                 'ClassName' => get_class($context),
                 'ID' => $context->ID,
-                'Link' => $context->Link()
+                'Link' => $context->hasMethod('Link') ? $context->Link() : ''
             ]
         ]);
 


### PR DESCRIPTION
Added a default notification type which is a wide-range
broadcast-to-users notification type to send a notification to multiple
users at once.

New data model:

* BroadcastNotification - allows Title, Content (used in message) and
Groups to send to