### PR TITLE
Remove CMS requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
   ],
   "require": {
     "php": ">=5.6.0",
-    "silverstripe/cms": "^4.0",
     "silverstripe/framework": "^4.0",
     "symbiote/silverstripe-multivaluefield": "^5.0"
   },


### PR DESCRIPTION
This module doesn't appear to need the CMS, yet requires it.

This PR removes the requirement.