### PR TITLE
Do _not_ send internal notifications to non-member objects

### DIFF
--- a/src/Service/InternalNotificationSender.php
+++ b/src/Service/InternalNotificationSender.php
@@ -41,6 +41,10 @@ class InternalNotificationSender implements NotificationSender
      */
     public function sendToUser($notification, $context, $user, $data)
     {
+        if (!($user instanceof Member)) {
+            // don't send to non-member user object types
+            return;
+        }
         $subject = $notification->format($notification->Title, $context, $user, $data);
 
         $content = $notification->NotificationContent();


### PR DESCRIPTION
A "user" may be a non-member object (eg, a subscriber user)